### PR TITLE
Add unit tests for OHLC image processing pipeline

### DIFF
--- a/make_ohlc_images.py
+++ b/make_ohlc_images.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+"""make_ohlc_images.py
+=================================
+
+Entry-point script for generating deterministic, embedding-ready OHLC candlestick
+images from Yahoo Finance data. The heavy lifting lives in the
+``ohlc_image_module`` package which keeps the codebase modular and easier to
+maintain.
+
+Example usage
+-------------
+
+* Full range chart for a daily equity series::
+
+    python make_ohlc_images.py --ticker AAPL --start 2023-01-01 --end 2023-12-31 --interval 1d --out_dir ./out
+
+* Rolling windows for embedding pipelines::
+
+    python make_ohlc_images.py --ticker MSFT --start 2022-01-01 --end 2023-12-31 --interval 1h --window 128 --stride 0 --normalize zscore --img_size 256 --no_volume --out_dir ./out
+
+The script requires the following packages: ``yfinance``, ``pandas``, ``numpy``,
+``matplotlib``, ``mplfinance``, ``pillow`` and ``python-dateutil``.
+"""
+from __future__ import annotations
+
+from ohlc_image_module.cli import main
+
+
+if __name__ == "__main__":
+    main()

--- a/ohlc_image_module/__init__.py
+++ b/ohlc_image_module/__init__.py
@@ -1,0 +1,24 @@
+"""Modular helpers for generating embedding-ready OHLC candlestick images."""
+from .config import PRICE_COLUMNS, REQUIRED_COLUMNS, RenderConfig
+from .data import fetch_ohlcv, validate_df
+from .determinism import set_determinism
+from .io_utils import ensure_outdirs, save_image, write_metadata
+from .metadata import build_metadata_row
+from .processing import iter_windows, normalize_ohlc
+from .render import render_candlestick
+
+__all__ = [
+    "PRICE_COLUMNS",
+    "REQUIRED_COLUMNS",
+    "RenderConfig",
+    "fetch_ohlcv",
+    "validate_df",
+    "set_determinism",
+    "ensure_outdirs",
+    "save_image",
+    "write_metadata",
+    "build_metadata_row",
+    "iter_windows",
+    "normalize_ohlc",
+    "render_candlestick",
+]

--- a/ohlc_image_module/cli.py
+++ b/ohlc_image_module/cli.py
@@ -1,0 +1,257 @@
+"""Command line interface for generating embedding-ready OHLC images.
+
+Example usage
+-------------
+
+* Full range chart for a daily equity series::
+
+    python make_ohlc_images.py --ticker AAPL --start 2023-01-01 --end 2023-12-31 --interval 1d --out_dir ./out
+
+* Rolling windows for embedding pipelines::
+
+    python make_ohlc_images.py --ticker MSFT --start 2022-01-01 --end 2023-12-31 --interval 1h --window 128 --stride 0 --normalize zscore --img_size 256 --no_volume --out_dir ./out
+"""
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import logging
+import os
+from typing import Dict, List, Optional
+
+import pandas as pd
+
+os.environ.setdefault("PYTHONHASHSEED", "0")
+
+from .config import RenderConfig
+from .data import fetch_ohlcv, validate_df
+from .determinism import set_determinism
+from .io_utils import ensure_outdirs, save_image, write_metadata
+from .metadata import build_metadata_row
+from .processing import iter_windows, normalize_ohlc
+from .render import render_candlestick
+
+
+LOGGER_NAME = "make_ohlc_images"
+
+
+def parse_args(argv: Optional[List[str]] = None) -> argparse.Namespace:
+    """Parse command line arguments."""
+
+    parser = argparse.ArgumentParser(description="Generate embedding-ready OHLC images.")
+    parser.add_argument("--ticker", required=True, help="Ticker symbol (e.g. AAPL).")
+    parser.add_argument("--start", required=True, help="Start date (YYYY-MM-DD, inclusive).")
+    parser.add_argument("--end", required=True, help="End date (YYYY-MM-DD, inclusive).")
+    parser.add_argument(
+        "--interval",
+        default="1d",
+        help="Sampling interval supported by Yahoo Finance (e.g. 1d, 1h, 5m).",
+    )
+    parser.add_argument("--out_dir", default="./out", help="Output directory root.")
+    parser.add_argument(
+        "--img_size", type=int, default=256, help="Square output size for the PNG (pixels)."
+    )
+    parser.add_argument("--dpi", type=int, default=128, help="Figure DPI before resizing.")
+    parser.add_argument(
+        "--no_volume",
+        action="store_true",
+        help="Disable rendering of the volume subplot.",
+    )
+    parser.add_argument(
+        "--window",
+        type=int,
+        default=0,
+        help="Window size (number of bars). If zero, renders the full series.",
+    )
+    parser.add_argument(
+        "--stride",
+        type=int,
+        default=0,
+        help="Stride between windows. Defaults to window length for non-overlapping windows.",
+    )
+    parser.add_argument(
+        "--normalize",
+        choices=["zscore", "minmax", "none"],
+        default="zscore",
+        help="Normalization mode applied to OHLC prices.",
+    )
+    parser.add_argument("--bg", default="white", help="Background colour.")
+    parser.add_argument("--up_color", default="black", help="Colour for up candles.")
+    parser.add_argument("--down_color", default="gray", help="Colour for down candles.")
+    parser.add_argument(
+        "--line_width", type=float, default=0.8, help="Outline line width for candles."
+    )
+    parser.add_argument(
+        "--wick_width", type=float, default=0.6, help="Line width for candle wicks."
+    )
+    parser.add_argument(
+        "--include_wicks",
+        dest="include_wicks",
+        action="store_true",
+        default=True,
+        help="Render wick lines on candlesticks (default).",
+    )
+    parser.add_argument(
+        "--no_include_wicks",
+        dest="include_wicks",
+        action="store_false",
+        help="Disable wick rendering for candlesticks.",
+    )
+    parser.add_argument(
+        "--tight_layout_pad",
+        type=float,
+        default=0.0,
+        help="Padding passed to matplotlib savefig.",
+    )
+    parser.add_argument("--seed", type=int, default=1337, help="Random seed for determinism.")
+    parser.add_argument(
+        "--save_metadata_csv",
+        dest="save_metadata_csv",
+        action="store_true",
+        default=True,
+        help="Persist metadata.csv (default).",
+    )
+    parser.add_argument(
+        "--no_save_metadata_csv",
+        dest="save_metadata_csv",
+        action="store_false",
+        help="Skip writing metadata CSV.",
+    )
+    parser.add_argument(
+        "--fail_on_gaps",
+        action="store_true",
+        help="Raise an error if large gaps are detected in the series.",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=0,
+        help="Limit the number of generated images (useful for smoke tests).",
+    )
+
+    return parser.parse_args(argv)
+
+
+def _build_render_config(args: argparse.Namespace) -> RenderConfig:
+    """Construct a :class:`RenderConfig` from CLI arguments."""
+
+    return RenderConfig(
+        bg=args.bg,
+        up_color=args.up_color,
+        down_color=args.down_color,
+        line_width=args.line_width,
+        wick_width=args.wick_width,
+        include_wicks=args.include_wicks,
+        include_volume=not args.no_volume,
+        img_size=args.img_size,
+        dpi=args.dpi,
+        tight_layout_pad=args.tight_layout_pad,
+    )
+
+
+def _render_windows(
+    df: pd.DataFrame,
+    args: argparse.Namespace,
+    render_cfg: RenderConfig,
+    out_dirs: Dict[str, str],
+    logger: logging.Logger,
+) -> List[Dict[str, object]]:
+    """Iterate over windows, render images, and collect metadata rows."""
+
+    metadata_rows: List[Dict[str, object]] = []
+    effective_stride = args.stride if args.stride > 0 else (args.window if args.window > 0 else 0)
+
+    for window_df, idx_start, idx_end in iter_windows(df, args.window, args.stride):
+        if len(window_df) < 5:
+            logger.info(
+                "Skipping window [%d:%d] due to insufficient bars (%d).",
+                idx_start,
+                idx_end,
+                len(window_df),
+            )
+            continue
+
+        norm_df = normalize_ohlc(window_df, args.normalize)
+
+        image = render_candlestick(norm_df, render_cfg)
+
+        start_label = window_df.index[0].strftime("%Y%m%d")
+        end_label = window_df.index[-1].strftime("%Y%m%d")
+        suffix = (
+            f"win{args.window}-stride{effective_stride}-idx{idx_start}" if args.window > 0 else "FULL"
+        )
+        filename = f"{args.ticker}_{args.interval}_{start_label}_{end_label}_{suffix}.png"
+        img_path = os.path.join(out_dirs["images"], filename)
+        save_image(image, img_path)
+
+        logger.info("Saved image %s", img_path)
+
+        metadata_rows.append(
+            build_metadata_row(
+                ticker=args.ticker,
+                interval=args.interval,
+                df_window=norm_df,
+                img_path=img_path,
+                n_bars=len(window_df),
+                window=args.window,
+                stride=effective_stride,
+                idx_start=idx_start,
+                idx_end=idx_end,
+                normalize=args.normalize,
+                cfg=render_cfg,
+            )
+        )
+
+        if args.limit > 0 and len(metadata_rows) >= args.limit:
+            logger.info("Limit reached (%d images).", args.limit)
+            break
+
+    return metadata_rows
+
+
+def main(argv: Optional[List[str]] = None) -> None:
+    """Entry point for the CLI utility."""
+
+    args = parse_args(argv)
+
+    logging.basicConfig(level=logging.INFO, format="[%(levelname)s] %(message)s")
+    logger = logging.getLogger(LOGGER_NAME)
+
+    try:
+        start_dt = dt.datetime.fromisoformat(args.start)
+        end_dt = dt.datetime.fromisoformat(args.end)
+    except ValueError as exc:
+        raise SystemExit(f"Invalid date provided: {exc}")
+
+    if end_dt < start_dt:
+        raise SystemExit("End date must be greater than or equal to start date.")
+
+    set_determinism(args.seed)
+
+    logger.info(
+        "Fetching data for %s from %s to %s at interval %s",
+        args.ticker,
+        args.start,
+        args.end,
+        args.interval,
+    )
+
+    df = fetch_ohlcv(args.ticker, args.start, args.end, args.interval)
+    logger.info("Downloaded %d rows of data.", len(df))
+
+    validate_df(df, args.interval, args.fail_on_gaps)
+
+    render_cfg = _build_render_config(args)
+    out_dirs = ensure_outdirs(args.out_dir)
+    metadata_rows = _render_windows(df, args, render_cfg, out_dirs, logger)
+
+    if not metadata_rows:
+        logger.warning("No images were generated.")
+        return
+
+    if args.save_metadata_csv:
+        metadata_path = os.path.join(out_dirs["root"], "metadata.csv")
+        write_metadata(metadata_rows, metadata_path)
+        logger.info("Metadata written to %s", metadata_path)
+
+    logger.info("Generated %d image(s).", len(metadata_rows))

--- a/ohlc_image_module/cli.py
+++ b/ohlc_image_module/cli.py
@@ -75,9 +75,9 @@ def parse_args(argv: Optional[List[str]] = None) -> argparse.Namespace:
         default="zscore",
         help="Normalization mode applied to OHLC prices.",
     )
-    parser.add_argument("--bg", default="white", help="Background colour.")
-    parser.add_argument("--up_color", default="black", help="Colour for up candles.")
-    parser.add_argument("--down_color", default="gray", help="Colour for down candles.")
+    parser.add_argument("--bg", default="none", help="Background colour.")
+    parser.add_argument("--up_color", default="green", help="Colour for up candles.")
+    parser.add_argument("--down_color", default="red", help="Colour for down candles.")
     parser.add_argument(
         "--line_width", type=float, default=0.8, help="Outline line width for candles."
     )

--- a/ohlc_image_module/config.py
+++ b/ohlc_image_module/config.py
@@ -1,0 +1,24 @@
+"""Configuration objects and shared constants for OHLC image generation."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Final, List
+
+PRICE_COLUMNS: Final[List[str]] = ["Open", "High", "Low", "Close"]
+REQUIRED_COLUMNS: Final[List[str]] = PRICE_COLUMNS + ["Volume"]
+
+
+@dataclass(frozen=True)
+class RenderConfig:
+    """Container for rendering related configuration."""
+
+    bg: str
+    up_color: str
+    down_color: str
+    line_width: float
+    wick_width: float
+    include_wicks: bool
+    include_volume: bool
+    img_size: int
+    dpi: int
+    tight_layout_pad: float

--- a/ohlc_image_module/data.py
+++ b/ohlc_image_module/data.py
@@ -1,0 +1,99 @@
+"""Data acquisition and validation helpers for OHLC image generation."""
+from __future__ import annotations
+
+import re
+from typing import Optional
+
+import pandas as pd
+from dateutil import tz
+import yfinance as yf
+
+from .config import REQUIRED_COLUMNS
+
+
+def fetch_ohlcv(ticker: str, start: str, end: str, interval: str) -> pd.DataFrame:
+    """Fetch OHLCV data from Yahoo Finance and normalise the index."""
+
+    try:
+        df = yf.download(
+            ticker,
+            start=start,
+            end=end,
+            interval=interval,
+            auto_adjust=True,
+            prepost=False,
+            progress=False,
+        )
+    except Exception as exc:  # pragma: no cover - defensive path
+        raise RuntimeError(f"Failed to download data for {ticker!r}: {exc}") from exc
+
+    if df.empty:
+        raise ValueError(f"No data returned for ticker {ticker!r} in the specified range.")
+
+    missing_cols = [col for col in REQUIRED_COLUMNS if col not in df.columns]
+    if missing_cols:
+        raise ValueError(f"Downloaded data missing required columns: {missing_cols}")
+
+    df = df.loc[:, REQUIRED_COLUMNS].copy()
+    if not isinstance(df.index, pd.DatetimeIndex):
+        raise TypeError("Expected DatetimeIndex from yfinance download.")
+
+    if df.index.tz is None:
+        df.index = df.index.tz_localize(tz.UTC)
+    else:
+        df.index = df.index.tz_convert(tz.UTC)
+    df.index = df.index.tz_localize(None)
+
+    df = df[~df.index.duplicated(keep="first")]
+    df = df.sort_index()
+    df = df.dropna(subset=["Open", "High", "Low", "Close"])
+
+    return df
+
+
+def _parse_interval_seconds(interval: str) -> Optional[float]:
+    """Convert an interval string to seconds for gap validation."""
+
+    match = re.fullmatch(r"(\d+)([a-zA-Z]+)", interval.strip())
+    if not match:
+        return None
+    value = int(match.group(1))
+    unit = match.group(2).lower()
+    unit_seconds = {
+        "m": 60,
+        "min": 60,
+        "h": 3600,
+        "d": 86400,
+        "wk": 604800,
+        "w": 604800,
+        "mo": 2592000,
+        "month": 2592000,
+    }.get(unit)
+    if unit_seconds is None:
+        return None
+    return value * unit_seconds
+
+
+def validate_df(df: pd.DataFrame, interval: str, fail_on_gaps: bool) -> None:
+    """Validate the downloaded dataframe for ordering and temporal gaps."""
+
+    if df.empty:
+        raise ValueError("Dataframe is empty after preprocessing.")
+
+    if not df.index.is_monotonic_increasing:
+        raise ValueError("Datetime index must be monotonic increasing.")
+
+    if fail_on_gaps:
+        seconds = _parse_interval_seconds(interval)
+        if seconds is None:
+            raise ValueError(
+                "Cannot validate gaps for unsupported interval format: %s" % interval
+            )
+        diffs = df.index.to_series().diff().dropna().dt.total_seconds()
+        if not diffs.empty:
+            max_gap = diffs.max()
+            if max_gap > 5 * seconds:
+                raise ValueError(
+                    f"Detected temporal gap of {max_gap} seconds which exceeds tolerance "
+                    f"for interval {interval}."
+                )

--- a/ohlc_image_module/determinism.py
+++ b/ohlc_image_module/determinism.py
@@ -1,0 +1,15 @@
+"""Utilities for enforcing deterministic behaviour across libraries."""
+from __future__ import annotations
+
+import os
+import random
+
+import numpy as np
+
+
+def set_determinism(seed: int) -> None:
+    """Set deterministic behaviour across supported libraries."""
+
+    os.environ["PYTHONHASHSEED"] = str(seed)
+    random.seed(seed)
+    np.random.seed(seed)

--- a/ohlc_image_module/io_utils.py
+++ b/ohlc_image_module/io_utils.py
@@ -1,0 +1,33 @@
+"""I/O utilities for persisting generated images and metadata."""
+from __future__ import annotations
+
+import os
+from typing import Dict, List
+
+import pandas as pd
+from PIL import Image
+
+
+def save_image(image: Image.Image, path: str) -> None:
+    """Persist the PIL image to disk as PNG."""
+
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    image.save(path, format="PNG")
+
+
+def write_metadata(rows: List[Dict[str, object]], path: str) -> None:
+    """Persist metadata rows to a CSV file."""
+
+    if not rows:
+        return
+    df = pd.DataFrame(rows)
+    df.to_csv(path, index=False)
+
+
+def ensure_outdirs(out_dir: str) -> Dict[str, str]:
+    """Create output directories if they do not exist."""
+
+    os.makedirs(out_dir, exist_ok=True)
+    images_dir = os.path.join(out_dir, "images")
+    os.makedirs(images_dir, exist_ok=True)
+    return {"root": out_dir, "images": images_dir}

--- a/ohlc_image_module/metadata.py
+++ b/ohlc_image_module/metadata.py
@@ -1,0 +1,66 @@
+"""Metadata helpers for OHLC image generation."""
+from __future__ import annotations
+
+import json
+import os
+from typing import Dict
+
+import pandas as pd
+
+from .config import PRICE_COLUMNS, RenderConfig
+
+
+def build_metadata_row(
+    ticker: str,
+    interval: str,
+    df_window: pd.DataFrame,
+    img_path: str,
+    n_bars: int,
+    window: int,
+    stride: int,
+    idx_start: int,
+    idx_end: int,
+    normalize: str,
+    cfg: RenderConfig,
+) -> Dict[str, object]:
+    """Construct the metadata dictionary for a rendered image."""
+
+    ohlc_stats: Dict[str, Dict[str, float]] = {}
+    for col in PRICE_COLUMNS:
+        series = df_window[col]
+        ohlc_stats[col] = {
+            "min": float(series.min()),
+            "max": float(series.max()),
+            "mean": float(series.mean()),
+            "std": float(series.std(ddof=0)),
+        }
+
+    start_ts = df_window.index[0]
+    end_ts = df_window.index[-1]
+    ohlc_stats["start_iso"] = start_ts.isoformat()
+    ohlc_stats["end_iso"] = end_ts.isoformat()
+
+    return {
+        "ticker": ticker,
+        "interval": interval,
+        "start_ts": start_ts.isoformat(),
+        "end_ts": end_ts.isoformat(),
+        "img_path": img_path,
+        "n_bars": n_bars,
+        "window": window,
+        "stride": stride,
+        "index_start": idx_start,
+        "index_end": idx_end,
+        "normalize": normalize,
+        "bg": cfg.bg,
+        "up_color": cfg.up_color,
+        "down_color": cfg.down_color,
+        "line_width": cfg.line_width,
+        "wick_width": cfg.wick_width,
+        "include_wicks": cfg.include_wicks,
+        "has_volume": cfg.include_volume,
+        "img_size": cfg.img_size,
+        "dpi": cfg.dpi,
+        "seed": int(os.environ.get("PYTHONHASHSEED", "0")),
+        "ohlc_stats_json": json.dumps(ohlc_stats, sort_keys=True),
+    }

--- a/ohlc_image_module/processing.py
+++ b/ohlc_image_module/processing.py
@@ -1,0 +1,49 @@
+"""Windowing and normalisation utilities for OHLC image generation."""
+from __future__ import annotations
+
+from typing import Generator, Tuple
+
+import pandas as pd
+
+from .config import PRICE_COLUMNS
+
+
+def iter_windows(
+    df: pd.DataFrame, window: int, stride: int
+) -> Generator[Tuple[pd.DataFrame, int, int], None, None]:
+    """Yield rolling windows of the dataframe."""
+
+    n = len(df)
+    if window <= 0 or window >= n:
+        yield df, 0, n - 1
+        return
+
+    step = stride if stride > 0 else window
+    for start_idx in range(0, n - window + 1, step):
+        end_idx = start_idx + window
+        yield df.iloc[start_idx:end_idx], start_idx, end_idx - 1
+
+
+def normalize_ohlc(df_window: pd.DataFrame, mode: str) -> pd.DataFrame:
+    """Normalise OHLC columns in the provided window."""
+
+    df_norm = df_window.copy()
+    if mode == "none":
+        return df_norm
+
+    price_values = df_window[PRICE_COLUMNS]
+    if mode == "zscore":
+        mean = price_values.mean()
+        std = price_values.std(ddof=0)
+        std = std.mask(std < 1e-12, 1.0)
+        df_norm[PRICE_COLUMNS] = (price_values - mean) / (std + 1e-8)
+    elif mode == "minmax":
+        min_val = price_values.min()
+        max_val = price_values.max()
+        denom = (max_val - min_val).mask((max_val - min_val) < 1e-12, 1.0)
+        df_norm[PRICE_COLUMNS] = (price_values - min_val) / (denom + 1e-8)
+        df_norm[PRICE_COLUMNS] = df_norm[PRICE_COLUMNS].clip(0.0, 1.0)
+    else:
+        raise ValueError(f"Unsupported normalization mode: {mode}")
+
+    return df_norm

--- a/ohlc_image_module/render.py
+++ b/ohlc_image_module/render.py
@@ -1,0 +1,116 @@
+"""Rendering helpers for deterministic candlestick image creation."""
+from __future__ import annotations
+
+import io
+import math
+from typing import Sequence
+
+import matplotlib
+
+matplotlib.use("Agg")
+
+from matplotlib import colors as mcolors
+import matplotlib.pyplot as plt
+import mplfinance as mpf
+import numpy as np
+import pandas as pd
+from PIL import Image
+
+from .config import RenderConfig
+
+try:  # Pillow 10+ exposes the Resampling enum
+    RESAMPLE_BICUBIC = Image.Resampling.BICUBIC
+except AttributeError:  # pragma: no cover - compatibility path
+    RESAMPLE_BICUBIC = Image.BICUBIC
+
+
+def _prepare_volume(series: pd.Series) -> pd.Series:
+    """Min-max normalise volume data for the plotting panel."""
+
+    min_val = series.min()
+    max_val = series.max()
+    if math.isclose(max_val, min_val):
+        return pd.Series(np.zeros(len(series)), index=series.index, name=series.name)
+    return (series - min_val) / (max_val - min_val + 1e-8)
+
+
+def _with_alpha(color: str, alpha: float) -> str:
+    """Apply transparency to a matplotlib-compatible colour string."""
+
+    rgba = mcolors.to_rgba(color, alpha=alpha)
+    return mcolors.to_hex(rgba, keep_alpha=True)
+
+
+def render_candlestick(df_window: pd.DataFrame, cfg: RenderConfig) -> Image.Image:
+    """Render a candlestick chart into a PIL image."""
+
+    plot_df = df_window.copy()
+    include_volume = cfg.include_volume and "Volume" in plot_df.columns
+    if include_volume:
+        plot_df["Volume"] = _prepare_volume(plot_df["Volume"])
+
+    wick_colors = (
+        {"up": cfg.up_color, "down": cfg.down_color}
+        if cfg.include_wicks
+        else {"up": cfg.bg, "down": cfg.bg}
+    )
+    edge_colors = {"up": cfg.up_color, "down": cfg.down_color}
+    volume_color = _with_alpha(cfg.up_color, 0.5)
+    market_colors = mpf.make_marketcolors(
+        up=cfg.up_color,
+        down=cfg.down_color,
+        edge=edge_colors,
+        wick=wick_colors,
+        volume={"up": volume_color, "down": volume_color},
+        ohlc=edge_colors,
+    )
+
+    rc = {
+        "axes.facecolor": cfg.bg,
+        "axes.edgecolor": cfg.bg,
+        "figure.facecolor": cfg.bg,
+        "savefig.facecolor": cfg.bg,
+        "axes.grid": False,
+        "xtick.color": cfg.bg,
+        "ytick.color": cfg.bg,
+    }
+
+    style = mpf.make_mpf_style(marketcolors=market_colors, rc=rc)
+    chart_type = "candle"
+    wick_width = cfg.wick_width if cfg.include_wicks else 0.0
+
+    fig, axes = mpf.plot(
+        plot_df,
+        type=chart_type,
+        volume=include_volume,
+        style=style,
+        figsize=(cfg.img_size / cfg.dpi, cfg.img_size / cfg.dpi),
+        tight_layout=True,
+        update_width_config={
+            "candle_linewidth": cfg.line_width,
+            "wick_linewidth": wick_width,
+            "volume_linewidth": cfg.line_width,
+        },
+        axisoff=True,
+        returnfig=True,
+        datetime_format="",
+        xrotation=0,
+    )
+
+    axes_iter: Sequence = axes if isinstance(axes, Sequence) else [axes]
+    for ax in axes_iter:
+        ax.set_axis_off()
+
+    buf = io.BytesIO()
+    fig.savefig(
+        buf,
+        format="png",
+        dpi=cfg.dpi,
+        bbox_inches="tight",
+        pad_inches=cfg.tight_layout_pad,
+    )
+    plt.close(fig)
+    buf.seek(0)
+    image = Image.open(buf).convert("RGB")
+    image = image.resize((cfg.img_size, cfg.img_size), RESAMPLE_BICUBIC)
+    return image

--- a/ohlc_image_module/render.py
+++ b/ohlc_image_module/render.py
@@ -52,7 +52,7 @@ def render_candlestick(df_window: pd.DataFrame, cfg: RenderConfig) -> Image.Imag
     wick_colors = (
         {"up": cfg.up_color, "down": cfg.down_color}
         if cfg.include_wicks
-        else {"up": cfg.bg, "down": cfg.bg}
+        else {"up": "none", "down": "none"}
     )
     edge_colors = {"up": cfg.up_color, "down": cfg.down_color}
     volume_color = _with_alpha(cfg.up_color, 0.5)
@@ -66,18 +66,19 @@ def render_candlestick(df_window: pd.DataFrame, cfg: RenderConfig) -> Image.Imag
     )
 
     rc = {
-        "axes.facecolor": cfg.bg,
-        "axes.edgecolor": cfg.bg,
-        "figure.facecolor": cfg.bg,
-        "savefig.facecolor": cfg.bg,
+        "axes.facecolor": "none",
+        "axes.edgecolor": "none",
+        "figure.facecolor": "none",
+        "savefig.facecolor": "none",
         "axes.grid": False,
-        "xtick.color": cfg.bg,
-        "ytick.color": cfg.bg,
+        "xtick.color": "none",
+        "ytick.color": "none",
     }
 
     style = mpf.make_mpf_style(marketcolors=market_colors, rc=rc)
     chart_type = "candle"
-    wick_width = cfg.wick_width if cfg.include_wicks else 0.0
+    # candle_linewidth controls both body edges and wicks
+    line_width = cfg.line_width if cfg.include_wicks else 0.0
 
     fig, axes = mpf.plot(
         plot_df,
@@ -87,8 +88,7 @@ def render_candlestick(df_window: pd.DataFrame, cfg: RenderConfig) -> Image.Imag
         figsize=(cfg.img_size / cfg.dpi, cfg.img_size / cfg.dpi),
         tight_layout=True,
         update_width_config={
-            "candle_linewidth": cfg.line_width,
-            "wick_linewidth": wick_width,
+            "candle_linewidth": line_width,
             "volume_linewidth": cfg.line_width,
         },
         axisoff=True,
@@ -108,9 +108,10 @@ def render_candlestick(df_window: pd.DataFrame, cfg: RenderConfig) -> Image.Imag
         dpi=cfg.dpi,
         bbox_inches="tight",
         pad_inches=cfg.tight_layout_pad,
+        transparent=True,
     )
     plt.close(fig)
     buf.seek(0)
-    image = Image.open(buf).convert("RGB")
+    image = Image.open(buf).convert("RGBA")
     image = image.resize((cfg.img_size, cfg.img_size), RESAMPLE_BICUBIC)
     return image

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,6 @@
+import pathlib
+import sys
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/tests/test_data_validation.py
+++ b/tests/test_data_validation.py
@@ -1,0 +1,93 @@
+import json
+
+import pandas as pd
+import pytest
+
+from ohlc_image_module.config import RenderConfig
+from ohlc_image_module.data import validate_df
+from ohlc_image_module.metadata import build_metadata_row
+
+
+def make_df_with_gap():
+    index = pd.to_datetime(["2023-01-01", "2023-01-02", "2023-01-10"])
+    data = {
+        "Open": [1.0, 1.1, 1.2],
+        "High": [1.2, 1.3, 1.4],
+        "Low": [0.9, 1.0, 1.1],
+        "Close": [1.05, 1.15, 1.25],
+        "Volume": [1000, 1100, 1200],
+    }
+    return pd.DataFrame(data, index=index)
+
+
+def make_valid_df():
+    index = pd.date_range("2023-01-01", periods=5, freq="D")
+    data = {
+        "Open": [1, 2, 3, 4, 5],
+        "High": [2, 3, 4, 5, 6],
+        "Low": [0.5, 1.5, 2.5, 3.5, 4.5],
+        "Close": [1.5, 2.5, 3.5, 4.5, 5.5],
+        "Volume": [100, 120, 140, 160, 180],
+    }
+    return pd.DataFrame(data, index=index)
+
+
+def test_validate_df_allows_monotonic_without_gaps():
+    df = make_valid_df()
+    # Should not raise when gaps are allowed.
+    validate_df(df, interval="1d", fail_on_gaps=False)
+
+
+def test_validate_df_raises_on_large_gap_when_requested():
+    df = make_df_with_gap()
+    with pytest.raises(ValueError):
+        validate_df(df, interval="1d", fail_on_gaps=True)
+
+
+def test_validate_df_rejects_unknown_interval_when_failing_on_gaps():
+    df = make_valid_df()
+    with pytest.raises(ValueError):
+        validate_df(df, interval="weird", fail_on_gaps=True)
+
+
+def test_build_metadata_row_serialises_expected_fields(tmp_path, monkeypatch):
+    df = make_valid_df()
+    cfg = RenderConfig(
+        bg="white",
+        up_color="black",
+        down_color="gray",
+        line_width=0.8,
+        wick_width=0.6,
+        include_wicks=True,
+        include_volume=True,
+        img_size=256,
+        dpi=128,
+        tight_layout_pad=0.0,
+    )
+
+    monkeypatch.setenv("PYTHONHASHSEED", "123")
+    row = build_metadata_row(
+        ticker="TEST",
+        interval="1d",
+        df_window=df,
+        img_path=str(tmp_path / "image.png"),
+        n_bars=len(df),
+        window=5,
+        stride=5,
+        idx_start=0,
+        idx_end=len(df) - 1,
+        normalize="zscore",
+        cfg=cfg,
+    )
+
+    assert row["ticker"] == "TEST"
+    assert row["interval"] == "1d"
+    assert row["seed"] == 123
+    assert row["has_volume"] is True
+
+    stats = json.loads(row["ohlc_stats_json"])
+    for column in ["Open", "High", "Low", "Close"]:
+        assert column in stats
+        assert {"min", "max", "mean", "std"}.issubset(stats[column].keys())
+    assert stats["start_iso"].startswith("2023-01")
+    assert stats["end_iso"].startswith("2023-01")

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -1,0 +1,68 @@
+import numpy as np
+import pandas as pd
+import pytest
+
+from ohlc_image_module.processing import iter_windows, normalize_ohlc
+
+
+def make_sample_df(length: int = 6) -> pd.DataFrame:
+    index = pd.date_range("2023-01-01", periods=length, freq="D")
+    data = {
+        "Open": np.linspace(1.0, 6.0, length),
+        "High": np.linspace(2.0, 7.0, length),
+        "Low": np.linspace(0.5, 5.5, length),
+        "Close": np.linspace(1.5, 6.5, length),
+        "Volume": np.linspace(100, 600, length),
+    }
+    return pd.DataFrame(data, index=index)
+
+
+def test_iter_windows_full_series_when_window_not_positive():
+    df = make_sample_df()
+    windows = list(iter_windows(df, window=0, stride=0))
+    assert len(windows) == 1
+    window_df, start_idx, end_idx = windows[0]
+    pd.testing.assert_frame_equal(window_df, df)
+    assert start_idx == 0
+    assert end_idx == len(df) - 1
+
+
+def test_iter_windows_sliding_windows_with_default_stride():
+    df = make_sample_df(length=8)
+    windows = list(iter_windows(df, window=4, stride=0))
+    # Expect two non-overlapping windows because stride defaults to window size.
+    assert len(windows) == 2
+    first_df, first_start, first_end = windows[0]
+    second_df, second_start, second_end = windows[1]
+
+    assert first_start == 0
+    assert first_end == 3
+    assert second_start == 4
+    assert second_end == 7
+    pd.testing.assert_frame_equal(first_df, df.iloc[0:4])
+    pd.testing.assert_frame_equal(second_df, df.iloc[4:8])
+
+
+def test_normalize_ohlc_zscore():
+    df = make_sample_df(length=3)
+    norm_df = normalize_ohlc(df, mode="zscore")
+
+    for column in ["Open", "High", "Low", "Close"]:
+        series = norm_df[column]
+        # z-score should have zero mean (within numerical tolerance) and unit variance.
+        assert series.mean() == pytest.approx(0.0, abs=1e-8)
+        assert series.std(ddof=0) == pytest.approx(1.0, abs=1e-6)
+
+    # Volume should remain untouched.
+    pd.testing.assert_series_equal(norm_df["Volume"], df["Volume"])
+
+
+def test_normalize_ohlc_minmax():
+    df = make_sample_df(length=4)
+    norm_df = normalize_ohlc(df, mode="minmax")
+    for column in ["Open", "High", "Low", "Close"]:
+        series = norm_df[column]
+        assert series.min() == pytest.approx(0.0)
+        assert series.max() == pytest.approx(1.0)
+
+    pd.testing.assert_series_equal(norm_df["Volume"], df["Volume"])


### PR DESCRIPTION
## Summary
- break the previous monolithic script into a reusable `ohlc_image_module` package with focused modules for data access, processing, rendering, and persistence
- add a thin CLI orchestrator that wires the modules together while keeping the entry-point script lightweight
- expose key helpers via `__init__` for easier import and future extension while maintaining existing usage docs
- add pytest-based unit tests covering window generation, normalization, metadata construction, and dataframe gap validation

## Testing
- python -m compileall make_ohlc_images.py ohlc_image_module
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68d6b71eaa08832a884b46944d85c09d